### PR TITLE
Add one more justification: Proof by Contradiction (PC)

### DIFF
--- a/fitch.sty
+++ b/fitch.sty
@@ -220,6 +220,7 @@
   \def\be{\by{$\bot$E}}%
   \def\nne{\by{$\neg\neg$E}}%
   \def\r{\by{R}}%
+  \def\pc{\by{PC}}%
 }
 
 \newenvironment{nd}{\begingroup\nd*init\nd*beginc}{\nd*endc\endgroup}


### PR DESCRIPTION
Hi there,

I'm a student of computing at Australian National University. One of my courses, [COMP6260](https://comp.anu.edu.au/courses/comp1600/), introduces natural deduction using Fitch style.

There is one rule this course uses but I found missing in this wonderful style file. 

I think this is the very `*.sty` file used by the lecturers as well.

But it seems the slides are not accessible publicly so I included two screenshots of the slides that are most relevant to this pull request.

At the moment, I'm happy with the local version slightly modified as does this pull request, had it were not to be accepted.

I really appreciate you published recently the source code here and also on CTAN, making it easier for others to both install it using tlmgr and contribute it using git-based workflow. Many thanks.

![pc-1](https://github.com/OpenLogicProject/fitch/assets/49512984/86693f48-1442-4b8d-854c-4ec7c29c7eed)
![pc-2](https://github.com/OpenLogicProject/fitch/assets/49512984/179728c0-6858-4a43-a805-e9fc25fbe6ce)

  